### PR TITLE
Disable server VAD to prevent double audio commit errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -522,8 +522,7 @@ wss.on("connection", (twilioWS, req) => {
         voice: "shimmer",
         temperature: 0.6,
         input_audio_format:  "g711_ulaw",
-        output_audio_format: "g711_ulaw",
-        turn_detection: { type: "server_vad", threshold: 0.45 }
+        output_audio_format: "g711_ulaw"
       }
     }));
 


### PR DESCRIPTION
## Summary
- remove the server-side VAD setting so manual turn detection remains the sole source of audio commits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0642baac8322b4e09b3b84446c20