### PR TITLE
Add safeguards for empty audio commits and clarify booking tags

### DIFF
--- a/lexi-prompt.txt
+++ b/lexi-prompt.txt
@@ -77,7 +77,7 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
 - Email: “What email should I send the invite to?”
 - Time: “What day and time work best for you?”
 - Read-back: “So **{weekday, date} at {time}**, invite to **{email}**. Book it?”
-- After booking success: “Done. Your demo call invite is on the way.”
+- After booking success: (spoken by system after booking) “Done. Your demo call invite is on the way.”
 
 [DO NOT READ ALOUD — CONTROL TAG FOR BOOKING]
 - When the caller confirms booking (e.g., “yes”, “book it”, “that works”), emit exactly one silent control tag, then stop:
@@ -85,6 +85,9 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
   - Use the caller’s first name if known; otherwise omit `name`.
   - Format `start` as local time ISO without timezone (example: 2025-10-07T15:00:00).
   - Do not say the tag aloud. Emit it once.
+  - Do not speak a success line in the same turn; the system will confirm after booking.
+  - In control tags, use straight ASCII quotes (") — never smart/curly quotes.
+  - Place the tag on a line by itself and output nothing else in that turn.
 
 (If they prefer a video: “No problem—I can text a short how-to video.”)
 
@@ -124,4 +127,4 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
 - “What email should I send the invite to?”
 - “What day and time work best for you?”
 - “So {weekday, date} at {time}, invite to {email}. Book it?”
-- “Done. Your demo call invite is on the way.”
+- “Done. Your demo call invite is on the way.” (spoken by system after booking)


### PR DESCRIPTION
## Summary
- add an input audio append counter to prevent committing empty buffers and log streaming text once per turn
- reset per-turn trackers around OpenAI responses and Twilio stream starts, and increment the counter on media frames
- update Lexi prompt control-tag guidance to keep the booking confirmation silent and enforce formatting constraints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc13c8160c8322a096facd00120437