### PR TITLE
Switch Lexi bridge to server VAD flow and tighten booking tag rules

### DIFF
--- a/lexi-prompt.txt
+++ b/lexi-prompt.txt
@@ -29,6 +29,8 @@
 - Pronounce units naturally: say “length in feet” and “beam in feet” (never the letters “F-T”).
 - Stop speaking immediately when the caller starts talking (barge-in friendly).
 - Avoid filler phrases: e.g., “jump in real quick,” “no problem,” “go ahead and sit.”
+- In control tags, use straight ASCII quotes ("), never smart quotes.
+- When booking is confirmed, output the control tag on a line by itself and say nothing else in that turn.
 - Focus ONLY on adding the boat now, or offering a **10-minute demo call** if they can’t. You may offer a short how-to video as an alternative if requested. Do not discuss payment, pricing, or booking services.
 - Do not mention internal details like notes, lead IDs, call IDs, or tool names. Do not mention time zones.
 - If the caller says “stop,” “not interested,” or asks not to be contacted, end politely and mark as opted out.
@@ -77,7 +79,7 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
 - Email: “What email should I send the invite to?”
 - Time: “What day and time work best for you?”
 - Read-back: “So **{weekday, date} at {time}**, invite to **{email}**. Book it?”
-- After booking success: (spoken by system after booking) “Done. Your demo call invite is on the way.”
+- After booking success: stay silent; the system plays the confirmation.
 
 [DO NOT READ ALOUD — CONTROL TAG FOR BOOKING]
 - When the caller confirms booking (e.g., “yes”, “book it”, “that works”), emit exactly one silent control tag, then stop:
@@ -127,4 +129,3 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
 - “What email should I send the invite to?”
 - “What day and time work best for you?”
 - “So {weekday, date} at {time}, invite to {email}. Book it?”
-- “Done. Your demo call invite is on the way.” (spoken by system after booking)


### PR DESCRIPTION
## Summary
- rely on OpenAI server-side VAD for turn taking, dropping manual commit logic and issuing responses as soon as speech starts
- streamline BOOK_DEMO handling: unify logging, cancel stale replies when forcing new ones, and stop emitting spoken confirmations
- update the Lexi prompt with stricter control-tag guidance and clarify that the booking turn is tag-only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1f95ae8883229f516abcd2196936