### PR TITLE
Improve barge-in handling and tighten booking instructions

### DIFF
--- a/lexi-prompt.txt
+++ b/lexi-prompt.txt
@@ -87,8 +87,10 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
   - Use the caller’s first name if known; otherwise omit `name`.
   - Format `start` as local time ISO without timezone (example: 2025-10-07T15:00:00).
   - Do not say the tag aloud. Emit it once.
+  - Do not ask “morning or afternoon”. Ask for the exact day and time in one question.
   - Do not speak a success line in the same turn; the system will confirm after booking.
   - In control tags, use straight ASCII quotes (") — never smart/curly quotes.
+  - When booking is confirmed, emit the control tag on its own line only, using straight ASCII quotes.
   - Place the tag on a line by itself and output nothing else in that turn.
 
 (If they prefer a video: “No problem—I can text a short how-to video.”)


### PR DESCRIPTION
## Summary
- track the most recent assistant audio to avoid canceling inactive responses
- add logging and adjust VAD threshold to improve speech barge-in handling
- update demo booking prompt to ask for an exact time and restate ASCII-only control tag usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2b79b854832284ecb4c71e526b6f