### PR TITLE
Implement booking latch and confirmation classifier flow

### DIFF
--- a/lexi-prompt.txt
+++ b/lexi-prompt.txt
@@ -79,6 +79,8 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
 - Email: “What email should I send the invite to?”
 - Time: “What day and time work best for you?”
 - Read-back: “So **{weekday, date} at {time}**, invite to **{email}**. Book it?”
+- Immediately before asking “Book it?”, output a silent control tag line (nothing else) with the captured details:
+  [[BOOKING_READY email="{email}" start="{YYYY-MM-DDTHH:mm:ss}"]]
 - After booking success: stay silent; the system plays the confirmation.
 
 [DO NOT READ ALOUD — CONTROL TAG FOR BOOKING]


### PR DESCRIPTION
## Summary
- add per-call booking latch state, BOOKING_READY tag detection, and safer barge-in timing
- classify caller confirmations with a YES/NO realtime turn and schedule demos server-side with logging
- stabilize audio handling by committing μ-law frames consistently and update Lexi prompt with BOOKING_READY tag rule

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68dc40cad45c8322a22502d014cb027b