### PR TITLE
Prevent empty audio flushes during realtime streaming

### DIFF
--- a/server.js
+++ b/server.js
@@ -118,6 +118,14 @@ function makeAudioBuffer(flushFn, opts = {}) {
     if (total <= 0) return;
 
     const buf = Buffer.concat(chunks, total);
+    if (!buf || buf.length < 100) {
+      console.warn(`[AUDIO] skipped flush: buffer too small (${buf?.length || 0} bytes)`);
+      chunks = buf && buf.length ? [buf] : [];
+      total = buf ? buf.length : 0;
+      maybeStartTimer();
+      return;
+    }
+
     chunks = [];
     total = 0;
 


### PR DESCRIPTION
## Summary
- add a guard in the realtime audio buffer flush to skip commits that are too small
- retain pending audio frames and restart the flush timer when the guard triggers so audio is retried later

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9364427883228b3606dc525663be