### PR TITLE
fix: ensure live call booking tags post to schedule route

### DIFF
--- a/lexi-prompt.txt
+++ b/lexi-prompt.txt
@@ -133,3 +133,12 @@ You are an outreach agent for The Wave App. Your purpose is to warmly help recen
 - “What email should I send the invite to?”
 - “What day and time work best for you?”
 - “So {weekday, date} at {time}, invite to {email}. Book it?”
+When the caller agrees to book a demo or provides an email and time, emit exactly one control tag on its own line:
+
+[[BOOK_DEMO email="<email>" start="<YYYY-MM-DDTHH:mm>"]]
+
+Rules:
+- Use 24-hour time in the caller’s timezone.
+- The tag line must contain no additional words or punctuation.
+- If the caller gives only time or only email, ask for the missing piece succinctly.
+- Once both are known, emit the tag immediately.


### PR DESCRIPTION
## Summary
- guard the realtime audio buffer so empty or tiny flushes are skipped before committing to OpenAI
- update the Lexi system prompt to emit the BOOK_DEMO control tag when email and time are known
- parse BOOK_DEMO tags during live calls and POST bookings to the /schedule-demo-graph endpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9656eb688322a34d162632e86248