### PR TITLE
Fix Graph event payload schema for calendar invites

### DIFF
--- a/routes/book-demo.js
+++ b/routes/book-demo.js
@@ -1,34 +1,46 @@
 const express = require('express');
 const router = express.Router();
-const { createCalendarInvite } = require('../graph-calendar');
+const { getAppToken, createGraphEvent } = require('../graph-calendar');
 
 router.post('/schedule-demo-graph', async (req, res) => {
   const rid = req.rid || 'no-rid';
   try {
-    const { email, start, subject, location } = req.body || {};
+    const { email, start, subject = 'Wave Demo', location = 'Online' } = req.body || {};
     if (!email || !start) {
       console.warn(`[BOOK ${rid}] missing fields`, { email, start });
       return res.status(400).json({ error: 'email and start required' });
     }
+    const organizer = process.env.DEMO_ORGANIZER_UPN || process.env.ORGANIZER_EMAIL;
+    if (!organizer) {
+      console.warn('[GRAPH] Organizer not configured; set DEMO_ORGANIZER_UPN or ORGANIZER_EMAIL');
+      return res.status(500).json({ error: 'Organizer not configured' });
+    }
     const startISO = new Date(start).toISOString();
     const endISO = new Date(new Date(startISO).getTime() + 30 * 60000).toISOString();
 
-    console.log(`[BOOK ${rid}] creating invite`, { email, startISO, endISO });
+    console.log(`[BOOK ${rid}] creating invite`, { email, startISO, endISO, location });
 
-    const evt = await createCalendarInvite({
-      subject: subject || 'Wave Demo',
-      bodyHtml: `<p>Your Wave demo is confirmed.</p>`,
-      attendees: [email],
-      startISO,
-      endISO,
-      location: location || 'Online (Teams)',
+    console.log('[GRAPH] acquiring app token…');
+    const token = await getAppToken();
+    console.log('[GRAPH] token OK');
+
+    const result = await createGraphEvent({
+      token,
+      organizer,
+      eventInput: { email, subject, startISO, endISO, location },
+      logger: console,
     });
 
-    console.log(`[BOOK ${rid}] SUCCESS eventId=${evt?.id}`);
-    res.status(201).json({ ok: true, eventId: evt?.id });
+    console.log(`[BOOK ${rid}] SUCCESS eventId=${result?.id}`);
+    res.status(201).json({ ok: true, id: result?.id || null, eventId: result?.id || null });
   } catch (err) {
-    console.error(`[BOOK ${rid}] FAILED`, { message: err.message, stack: err.stack });
-    res.status(500).json({ error: 'booking_failed', details: err.message });
+    console.error(`[BOOK ${rid}] FAILED`, {
+      status: err?.status || 0,
+      body: err?.body,
+      message: err?.message,
+      stack: err?.stack,
+    });
+    res.status(502).json({ ok: false, error: 'graph_create_failed', detail: err?.body || err?.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- replace the Graph calendar helper with a payload builder that emits start/end/location/attendees objects and logs the final JSON before sending it
- update the /schedule-demo-graph route to fetch a token, call the new helper, and return richer success/error details when creating invites

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea300637c8322a06a8a97b63c8451