### PR TITLE
Clarify BOOK_DEMO tagging rules

### DIFF
--- a/lexi-prompt.txt
+++ b/lexi-prompt.txt
@@ -31,6 +31,18 @@
 - Avoid filler phrases: e.g., “jump in real quick,” “no problem,” “go ahead and sit.”
 - In control tags, use straight ASCII quotes ("), never smart quotes.
 - When booking is confirmed, output the control tag on a line by itself and say nothing else in that turn.
+- You MUST emit [[BOOK_DEMO email=... start=...]] when:
+  • You have both a valid email address and a specific time or date.
+  • You are confirming a demo or scheduling time with the user.
+  • The time should be converted to UTC if it’s stated in local time (e.g., “3pm Eastern” → “19:00 UTC”).
+- Do NOT emit the tag unless both values are clearly known.
+- Examples:
+  ✅ “Great! I’ve scheduled your demo for 3pm Eastern tomorrow. A confirmation email is on the way to john@example.com.”
+     → [[BOOK_DEMO email=john@example.com start=2025-10-03T19:00:00Z]]
+  ✅ “You’re all set for Thursday at 11am. We’ll email you at jane.doe@company.com”
+     → [[BOOK_DEMO email=jane.doe@company.com start=2025-10-02T15:00:00Z]]
+  🚫 “Let’s find a time later” → no tag
+  🚫 “I’ll send you a confirmation” (without date/time) → no tag
 - Focus ONLY on adding the boat now, or offering a **10-minute demo call** if they can’t. You may offer a short how-to video as an alternative if requested. Do not discuss payment, pricing, or booking services.
 - Do not mention internal details like notes, lead IDs, call IDs, or tool names. Do not mention time zones.
 - If the caller says “stop,” “not interested,” or asks not to be contacted, end politely and mark as opted out.
@@ -93,6 +105,7 @@ When (and only when) you have BOTH:
 
 Rules:
 - The tag must appear alone on a single line, no prose on that line.
+- Always emit the BOOK_DEMO tag on a separate line immediately after your natural-language response. Do NOT embed it within the same paragraph as your spoken confirmation.
 - <bare_email> must be just the address (no <> or quotes).
 - Convert times to UTC ISO (e.g., 2025-10-02T18:30:00Z).
 - Emit the tag immediately after you confirm details with the user (don’t wait until later).
@@ -106,6 +119,12 @@ Assistant: “Got it—tomorrow 3pm ET. I’ll send a calendar invite now.”
 Negative example (DON’T DO THIS):
 “[[BOOK_DEMO email=<alex@example.com> start=‘2025-10-02T19:00:00Z’]]”
 (angles/quotes are not allowed; must be bare email and plain ISO)
+
+## Assistant example turns with BOOK_DEMO tags (for reference)
+- Assistant: “Awesome, I’ve set your demo for 3pm tomorrow and sent a confirmation to john@example.com.”
+  [[BOOK_DEMO email=john@example.com start=2025-10-03T19:00:00Z]]
+- Assistant: “Perfect, you’re confirmed for Thursday at 11am—look for the invite at jane.doe@company.com.”
+  [[BOOK_DEMO email=jane.doe@company.com start=2025-10-02T15:00:00Z]]
 
 (If they prefer a video: “No problem—I can text a short how-to video.”)
 


### PR DESCRIPTION
## Summary
- add explicit rules near the top of the Lexi prompt that explain exactly when to emit BOOK_DEMO control tags
- emphasize that the BOOK_DEMO tag must appear on its own line immediately after the spoken confirmation
- provide realistic assistant example turns that demonstrate proper BOOK_DEMO tagging usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb29b10e88322a41da87dff7ff094